### PR TITLE
Fix licence in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,4 @@ We use [SemVer](http://semver.org/) for versioning. For the versions available, 
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details.
+This project is licensed under the Apache License 2.0 - see the [LICENSE.md](LICENSE.md) file for details.


### PR DESCRIPTION
Previously noted as "MIT", but we have a "Apache 2.0".